### PR TITLE
Contact form email bug fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -266,8 +266,8 @@ def contact():
         with SMTP("smtp.gmail.com", 465) as connection:
             connection.login(MY_EMAIL, PASSWORD)
             connection.sendmail(
-                from_addr=MY_EMAIL,
-                to_addrs=email,
+                from_addr=email,
+                to_addrs=MY_EMAIL,
                 msg=f"Subject: New Message from blog \n\nName: {name}\nEmail: {email}\nPhone Number: {phone}\nMessage: {message}"
             )
         return render_template("contact.html", year=current_date, msg_sent=True, logged_in=current_user.is_authenticated)


### PR DESCRIPTION
Flipped the send to / receive email addresses.

You may have issues sending using their email address. 
That may suffice.
A possible fix could be to send from and to your email address, but include the email address in the message for reply's.